### PR TITLE
[front] msw, storybookのバージョンを最新に更新した

### DIFF
--- a/front/e2e/riders.spec.ts
+++ b/front/e2e/riders.spec.ts
@@ -22,6 +22,8 @@ test("ライダー情報を編集できる", async ({ page }) => {
     page.getByRole("heading", { name: "Tadej Pogacar" })
   ).toBeVisible();
 
+  // フォームに入力できること
+  await expect(page.getByRole("button", { name: "Submit" })).toBeVisible();
   await page.getByLabel("姓").fill("Poga");
   await page.getByLabel("名").fill("Tade");
   await page.getByRole("button", { name: "Submit" }).click();

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -45,9 +45,9 @@
         "eslint-plugin-storybook": "^0.6.13",
         "jest": "^29.6.4",
         "jest-environment-jsdom": "^29.6.4",
-        "msw": "^1.2.5",
+        "msw": "^1.3.1",
         "msw-storybook-addon": "^1.8.0",
-        "storybook": "^7.3.2"
+        "storybook": "^7.4.3"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -811,6 +811,7 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz",
       "integrity": "sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-nullish-coalescing-operator instead.",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6",
@@ -862,6 +863,7 @@
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.21.0.tgz",
       "integrity": "sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-optional-chaining instead.",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2",
@@ -2262,9 +2264,9 @@
       }
     },
     "node_modules/@babel/register": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.22.5.tgz",
-      "integrity": "sha512-vV6pm/4CijSQ8Y47RH5SopXzursN35RQINfGJkmOlcpAtGuf94miFvIPhCKGQN7WGIcsgG1BHEX2KVdTYwTwUQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.22.15.tgz",
+      "integrity": "sha512-V3Q3EqoQdn65RCgTLwauZaTfd1ShhwPmbBv+1dkZV/HpCGMKVyn6oFcRlI7RaKqiDQjX2Qd3AuoEguBgdjIKlg==",
       "dev": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -6017,16 +6019,16 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.17.9",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.9.tgz",
-      "integrity": "sha512-4LVGt03RobMH/7ZrbHqRxQrS9cc2uh+iNKSj8UWr8M26A2i793ju+csaB5zaqYltqJmA2jUq4VeYfKmVqvsXQg==",
+      "version": "0.17.10",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
+      "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
       "dev": true,
       "dependencies": {
         "@open-draft/until": "^1.0.3",
         "@types/debug": "^4.1.7",
         "@xmldom/xmldom": "^0.8.3",
         "debug": "^4.3.3",
-        "headers-polyfill": "^3.1.0",
+        "headers-polyfill": "3.2.5",
         "outvariant": "^1.2.1",
         "strict-event-emitter": "^0.2.4",
         "web-encoding": "^1.1.5"
@@ -7566,15 +7568,15 @@
       }
     },
     "node_modules/@storybook/builder-manager": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-7.3.2.tgz",
-      "integrity": "sha512-M0zdzpnZSg6Gd/QiIbOJkVoifAADpMT85NOC5zuAg3h3o29hedVBAigv/CE2nSbuwZtqPifjxs1AUh7wgtmj8A==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-7.4.3.tgz",
+      "integrity": "sha512-6jzxZ2J1jFaZXn7ZucEgV6XyUe+FJ9uuoMRZcZefoCKeXK/BOPCefijYWP3DPgqqVh3/JLUglIpz0MH9k8cBaw==",
       "dev": true,
       "dependencies": {
         "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
-        "@storybook/core-common": "7.3.2",
-        "@storybook/manager": "7.3.2",
-        "@storybook/node-logger": "7.3.2",
+        "@storybook/core-common": "7.4.3",
+        "@storybook/manager": "7.4.3",
+        "@storybook/node-logger": "7.4.3",
         "@types/ejs": "^3.1.1",
         "@types/find-cache-dir": "^3.2.1",
         "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.10",
@@ -7591,6 +7593,200 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/channels": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.4.3.tgz",
+      "integrity": "sha512-lIoRX3EV0wKPX8ojIrJUtsOv4+Gv8r9pfJpam/NdyYd+rs0AjDK13ieINRfBMnJkfjsWa3vmZtGMBEVvDKwTMw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.4.3",
+        "@storybook/core-events": "7.4.3",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/client-logger": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.4.3.tgz",
+      "integrity": "sha512-Nhngo9X4HjN00aRhgIVGWbwkWPe0Fz8PySuxnd8nAxSsz7KpdLFyYo2TbZZ3TX51FG5Fxcb0G5OHuunItP7EWQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/core-common": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.4.3.tgz",
+      "integrity": "sha512-jwIBUnWitZzw0VfKC77yN8DvTyePLVnAjbA2lPMbMIdO9ZY2lfD4AQ4QpuWsxJyAllFC4slOFDNgCDHx2AlYWw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "7.4.3",
+        "@storybook/node-logger": "7.4.3",
+        "@storybook/types": "7.4.3",
+        "@types/find-cache-dir": "^3.2.1",
+        "@types/node": "^16.0.0",
+        "@types/node-fetch": "^2.6.4",
+        "@types/pretty-hrtime": "^1.0.0",
+        "chalk": "^4.1.0",
+        "esbuild": "^0.18.0",
+        "esbuild-register": "^3.4.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/core-events": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.4.3.tgz",
+      "integrity": "sha512-FRfipCijMnVbGxL1ZjOLM836lyd/TGQcUFeVjTQWW/+pIGHELqDHiYeq68hqoGTKl0G0np59CJPWYTUZA4Dl9Q==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/node-logger": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.4.3.tgz",
+      "integrity": "sha512-pL13PPMUttflTWKVeDIKxPIJtBRl50Fzck12/7uiNROtBIrSV9DZSgOjInAazjo4tl+7fDj9lgkGeMEz00E8aQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/types": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.4.3.tgz",
+      "integrity": "sha512-DrHC1hIiw9TqDILLokDnvbUPNxGz5iJaYFEv30uvYE0s9MvgEUPblCChEUjaHOps7zQTznMPf8ULfoXlgqxk2A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.4.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@types/node": {
+      "version": "16.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
+      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
+      "dev": true
+    },
+    "node_modules/@storybook/builder-manager/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/glob": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.5.tgz",
+      "integrity": "sha512-bYUpUD7XDEHI4Q2O5a7PXGvyw4deKR70kHiDxzQbe925wbZknhOzUt2xBgTkYL6RBcVeXYuD9iNYeqoWbBZQnA==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.0.3",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@storybook/builder-webpack5": {
@@ -7683,22 +7879,23 @@
       }
     },
     "node_modules/@storybook/cli": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-7.3.2.tgz",
-      "integrity": "sha512-RnqE/6KSelL9TQ44uCIU5xvUhY9zXM2Upanr0hao72x44rvlGQbV262pHdkVIYsn0wi8QzYtnoxQPLSqUfUDfA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-7.4.3.tgz",
+      "integrity": "sha512-/lGtXbzNropsCF4srEGxiHzCU7b2wlV13LrSj3H3zOnHEAJlFcNpyNzO+4jKHfNTjjqEtcRGJ1OxrSYuGZTVjg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
         "@babel/types": "^7.22.5",
         "@ndelangen/get-tarball": "^3.0.7",
-        "@storybook/codemod": "7.3.2",
-        "@storybook/core-common": "7.3.2",
-        "@storybook/core-server": "7.3.2",
-        "@storybook/csf-tools": "7.3.2",
-        "@storybook/node-logger": "7.3.2",
-        "@storybook/telemetry": "7.3.2",
-        "@storybook/types": "7.3.2",
+        "@storybook/codemod": "7.4.3",
+        "@storybook/core-common": "7.4.3",
+        "@storybook/core-events": "7.4.3",
+        "@storybook/core-server": "7.4.3",
+        "@storybook/csf-tools": "7.4.3",
+        "@storybook/node-logger": "7.4.3",
+        "@storybook/telemetry": "7.4.3",
+        "@storybook/types": "7.4.3",
         "@types/semver": "^7.3.4",
         "@yarnpkg/fslib": "2.10.3",
         "@yarnpkg/libzip": "2.3.0",
@@ -7738,6 +7935,147 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/cli/node_modules/@storybook/channels": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.4.3.tgz",
+      "integrity": "sha512-lIoRX3EV0wKPX8ojIrJUtsOv4+Gv8r9pfJpam/NdyYd+rs0AjDK13ieINRfBMnJkfjsWa3vmZtGMBEVvDKwTMw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.4.3",
+        "@storybook/core-events": "7.4.3",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/client-logger": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.4.3.tgz",
+      "integrity": "sha512-Nhngo9X4HjN00aRhgIVGWbwkWPe0Fz8PySuxnd8nAxSsz7KpdLFyYo2TbZZ3TX51FG5Fxcb0G5OHuunItP7EWQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/core-common": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.4.3.tgz",
+      "integrity": "sha512-jwIBUnWitZzw0VfKC77yN8DvTyePLVnAjbA2lPMbMIdO9ZY2lfD4AQ4QpuWsxJyAllFC4slOFDNgCDHx2AlYWw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "7.4.3",
+        "@storybook/node-logger": "7.4.3",
+        "@storybook/types": "7.4.3",
+        "@types/find-cache-dir": "^3.2.1",
+        "@types/node": "^16.0.0",
+        "@types/node-fetch": "^2.6.4",
+        "@types/pretty-hrtime": "^1.0.0",
+        "chalk": "^4.1.0",
+        "esbuild": "^0.18.0",
+        "esbuild-register": "^3.4.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/core-events": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.4.3.tgz",
+      "integrity": "sha512-FRfipCijMnVbGxL1ZjOLM836lyd/TGQcUFeVjTQWW/+pIGHELqDHiYeq68hqoGTKl0G0np59CJPWYTUZA4Dl9Q==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/csf-tools": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.4.3.tgz",
+      "integrity": "sha512-nkVakGx2kzou91lGcxnyFNiSEdnpx1a53lQTl/DLm0QpDbqQuu3ZbZWXZCpXV97t/6YPeCCnGLXodnI7PZyZBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.22.9",
+        "@babel/parser": "^7.22.7",
+        "@babel/traverse": "^7.22.8",
+        "@babel/types": "^7.22.5",
+        "@storybook/csf": "^0.1.0",
+        "@storybook/types": "7.4.3",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/node-logger": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.4.3.tgz",
+      "integrity": "sha512-pL13PPMUttflTWKVeDIKxPIJtBRl50Fzck12/7uiNROtBIrSV9DZSgOjInAazjo4tl+7fDj9lgkGeMEz00E8aQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/types": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.4.3.tgz",
+      "integrity": "sha512-DrHC1hIiw9TqDILLokDnvbUPNxGz5iJaYFEv30uvYE0s9MvgEUPblCChEUjaHOps7zQTznMPf8ULfoXlgqxk2A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.4.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@types/node": {
+      "version": "16.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
+      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
+      "dev": true
+    },
+    "node_modules/@storybook/cli/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@storybook/cli/node_modules/commander": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
@@ -7745,6 +8083,80 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/glob": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.5.tgz",
+      "integrity": "sha512-bYUpUD7XDEHI4Q2O5a7PXGvyw4deKR70kHiDxzQbe925wbZknhOzUt2xBgTkYL6RBcVeXYuD9iNYeqoWbBZQnA==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.0.3",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@storybook/client-api": {
@@ -7775,18 +8187,18 @@
       }
     },
     "node_modules/@storybook/codemod": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-7.3.2.tgz",
-      "integrity": "sha512-B2P91aYhlxdk7zeQOq0VBnDox2HEcboP2unSh6Vcf4V8j2FCdPvBIM7ZkT9p15FHfyOHvvrtf56XdBIyD8/XJA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-7.4.3.tgz",
+      "integrity": "sha512-UwnsyVeUa+wLIeE/zO0slV3mwsPgS3DstZAWbjWUfFlJKZjgg1++Zkv0GmxkEyirsnf/g4r6Aq+KhIdIHmdzag==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.22.9",
         "@babel/preset-env": "^7.22.9",
         "@babel/types": "^7.22.5",
         "@storybook/csf": "^0.1.0",
-        "@storybook/csf-tools": "7.3.2",
-        "@storybook/node-logger": "7.3.2",
-        "@storybook/types": "7.3.2",
+        "@storybook/csf-tools": "7.4.3",
+        "@storybook/node-logger": "7.4.3",
+        "@storybook/types": "7.4.3",
         "@types/cross-spawn": "^6.0.2",
         "cross-spawn": "^7.0.3",
         "globby": "^11.0.2",
@@ -7794,6 +8206,97 @@
         "lodash": "^4.17.21",
         "prettier": "^2.8.0",
         "recast": "^0.23.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/channels": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.4.3.tgz",
+      "integrity": "sha512-lIoRX3EV0wKPX8ojIrJUtsOv4+Gv8r9pfJpam/NdyYd+rs0AjDK13ieINRfBMnJkfjsWa3vmZtGMBEVvDKwTMw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.4.3",
+        "@storybook/core-events": "7.4.3",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/client-logger": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.4.3.tgz",
+      "integrity": "sha512-Nhngo9X4HjN00aRhgIVGWbwkWPe0Fz8PySuxnd8nAxSsz7KpdLFyYo2TbZZ3TX51FG5Fxcb0G5OHuunItP7EWQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/core-events": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.4.3.tgz",
+      "integrity": "sha512-FRfipCijMnVbGxL1ZjOLM836lyd/TGQcUFeVjTQWW/+pIGHELqDHiYeq68hqoGTKl0G0np59CJPWYTUZA4Dl9Q==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/csf-tools": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.4.3.tgz",
+      "integrity": "sha512-nkVakGx2kzou91lGcxnyFNiSEdnpx1a53lQTl/DLm0QpDbqQuu3ZbZWXZCpXV97t/6YPeCCnGLXodnI7PZyZBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.22.9",
+        "@babel/parser": "^7.22.7",
+        "@babel/traverse": "^7.22.8",
+        "@babel/types": "^7.22.5",
+        "@storybook/csf": "^0.1.0",
+        "@storybook/types": "7.4.3",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/node-logger": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.4.3.tgz",
+      "integrity": "sha512-pL13PPMUttflTWKVeDIKxPIJtBRl50Fzck12/7uiNROtBIrSV9DZSgOjInAazjo4tl+7fDj9lgkGeMEz00E8aQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/types": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.4.3.tgz",
+      "integrity": "sha512-DrHC1hIiw9TqDILLokDnvbUPNxGz5iJaYFEv30uvYE0s9MvgEUPblCChEUjaHOps7zQTznMPf8ULfoXlgqxk2A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.4.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7975,26 +8478,26 @@
       }
     },
     "node_modules/@storybook/core-server": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-7.3.2.tgz",
-      "integrity": "sha512-TLMEptmfqYLu4bayRV5m8T3R50uR07Fwja1n/8CCmZOGWjnr5kXMFRkD7+hj7wm82yoidfd23bmVcRU9mlG+tg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-7.4.3.tgz",
+      "integrity": "sha512-yl9HaVwk/xJV9zq76n/oR1cE39wAFmNmKVPOJAtr3+c7wS0tnBkw7T+GqZ2Seyv+xkcZUWS8KRH74HqwPwG0Bw==",
       "dev": true,
       "dependencies": {
         "@aw-web-design/x-default-browser": "1.4.126",
         "@discoveryjs/json-ext": "^0.5.3",
-        "@storybook/builder-manager": "7.3.2",
-        "@storybook/channels": "7.3.2",
-        "@storybook/core-common": "7.3.2",
-        "@storybook/core-events": "7.3.2",
+        "@storybook/builder-manager": "7.4.3",
+        "@storybook/channels": "7.4.3",
+        "@storybook/core-common": "7.4.3",
+        "@storybook/core-events": "7.4.3",
         "@storybook/csf": "^0.1.0",
-        "@storybook/csf-tools": "7.3.2",
+        "@storybook/csf-tools": "7.4.3",
         "@storybook/docs-mdx": "^0.1.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager": "7.3.2",
-        "@storybook/node-logger": "7.3.2",
-        "@storybook/preview-api": "7.3.2",
-        "@storybook/telemetry": "7.3.2",
-        "@storybook/types": "7.3.2",
+        "@storybook/manager": "7.4.3",
+        "@storybook/node-logger": "7.4.3",
+        "@storybook/preview-api": "7.4.3",
+        "@storybook/telemetry": "7.4.3",
+        "@storybook/types": "7.4.3",
         "@types/detect-port": "^1.3.0",
         "@types/node": "^16.0.0",
         "@types/pretty-hrtime": "^1.0.0",
@@ -8015,7 +8518,7 @@
         "read-pkg-up": "^7.0.1",
         "semver": "^7.3.7",
         "serve-favicon": "^2.5.0",
-        "telejson": "^7.0.3",
+        "telejson": "^7.2.0",
         "tiny-invariant": "^1.3.1",
         "ts-dedent": "^2.0.0",
         "util": "^0.12.4",
@@ -8028,11 +8531,246 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/core-server/node_modules/@storybook/channels": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.4.3.tgz",
+      "integrity": "sha512-lIoRX3EV0wKPX8ojIrJUtsOv4+Gv8r9pfJpam/NdyYd+rs0AjDK13ieINRfBMnJkfjsWa3vmZtGMBEVvDKwTMw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.4.3",
+        "@storybook/core-events": "7.4.3",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/client-logger": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.4.3.tgz",
+      "integrity": "sha512-Nhngo9X4HjN00aRhgIVGWbwkWPe0Fz8PySuxnd8nAxSsz7KpdLFyYo2TbZZ3TX51FG5Fxcb0G5OHuunItP7EWQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/core-common": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.4.3.tgz",
+      "integrity": "sha512-jwIBUnWitZzw0VfKC77yN8DvTyePLVnAjbA2lPMbMIdO9ZY2lfD4AQ4QpuWsxJyAllFC4slOFDNgCDHx2AlYWw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "7.4.3",
+        "@storybook/node-logger": "7.4.3",
+        "@storybook/types": "7.4.3",
+        "@types/find-cache-dir": "^3.2.1",
+        "@types/node": "^16.0.0",
+        "@types/node-fetch": "^2.6.4",
+        "@types/pretty-hrtime": "^1.0.0",
+        "chalk": "^4.1.0",
+        "esbuild": "^0.18.0",
+        "esbuild-register": "^3.4.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/core-events": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.4.3.tgz",
+      "integrity": "sha512-FRfipCijMnVbGxL1ZjOLM836lyd/TGQcUFeVjTQWW/+pIGHELqDHiYeq68hqoGTKl0G0np59CJPWYTUZA4Dl9Q==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/csf-tools": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.4.3.tgz",
+      "integrity": "sha512-nkVakGx2kzou91lGcxnyFNiSEdnpx1a53lQTl/DLm0QpDbqQuu3ZbZWXZCpXV97t/6YPeCCnGLXodnI7PZyZBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.22.9",
+        "@babel/parser": "^7.22.7",
+        "@babel/traverse": "^7.22.8",
+        "@babel/types": "^7.22.5",
+        "@storybook/csf": "^0.1.0",
+        "@storybook/types": "7.4.3",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/node-logger": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.4.3.tgz",
+      "integrity": "sha512-pL13PPMUttflTWKVeDIKxPIJtBRl50Fzck12/7uiNROtBIrSV9DZSgOjInAazjo4tl+7fDj9lgkGeMEz00E8aQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/preview-api": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-7.4.3.tgz",
+      "integrity": "sha512-qKwfH2+qN1Zpz2UX6dQLiTU5x2JH3o/+jOY4GYF6c3atTm5WAu1OvCYAJVb6MdXfAhZNuPwDKnJR8VmzWplWBg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.4.3",
+        "@storybook/client-logger": "7.4.3",
+        "@storybook/core-events": "7.4.3",
+        "@storybook/csf": "^0.1.0",
+        "@storybook/global": "^5.0.0",
+        "@storybook/types": "7.4.3",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "synchronous-promise": "^2.0.15",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/types": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.4.3.tgz",
+      "integrity": "sha512-DrHC1hIiw9TqDILLokDnvbUPNxGz5iJaYFEv30uvYE0s9MvgEUPblCChEUjaHOps7zQTznMPf8ULfoXlgqxk2A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.4.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "16.18.46",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.46.tgz",
-      "integrity": "sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==",
+      "version": "16.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
+      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
       "dev": true
+    },
+    "node_modules/@storybook/core-server/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/glob": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.5.tgz",
+      "integrity": "sha512-bYUpUD7XDEHI4Q2O5a7PXGvyw4deKR70kHiDxzQbe925wbZknhOzUt2xBgTkYL6RBcVeXYuD9iNYeqoWbBZQnA==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.0.3",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@storybook/core-webpack": {
       "version": "7.3.2",
@@ -8174,9 +8912,9 @@
       }
     },
     "node_modules/@storybook/manager": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-7.3.2.tgz",
-      "integrity": "sha512-nA3XcnD36WUjgMCtID2M4DWYZh6MnabItXvKXGbNUkI8SVaIekc5nEgeplFyqutL11eKz3Es/FwwEP+mePbWfw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-7.4.3.tgz",
+      "integrity": "sha512-7U92tYwjt0DIKX7vCKNSZefuEavdnJYa5/zSjdlo0LtfBmGRBak1eq/sVLGfzrZ+wKIlCXgNh3f8OLy8RMnOOw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -8603,14 +9341,14 @@
       }
     },
     "node_modules/@storybook/telemetry": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-7.3.2.tgz",
-      "integrity": "sha512-BmgwaZGoR2ZzGZpcO5ipc4uMd9y28qmu9Ynx054Q3mb86daJrw4CU18TVi5UoFa9qmygQhoHx2gaK2QStNtqCg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-7.4.3.tgz",
+      "integrity": "sha512-gA7QfQSdDocNKP0KfrmIhD8ZgW5G4zZD/NL0OsATlkL3H/DehH3Ugjfffh7Ao2JZRXogHp8p9EQCVfPW7iKgBQ==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "7.3.2",
-        "@storybook/core-common": "7.3.2",
-        "@storybook/csf-tools": "7.3.2",
+        "@storybook/client-logger": "7.4.3",
+        "@storybook/core-common": "7.4.3",
+        "@storybook/csf-tools": "7.4.3",
         "chalk": "^4.1.0",
         "detect-package-manager": "^2.0.1",
         "fetch-retry": "^5.0.2",
@@ -8620,6 +9358,221 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/channels": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-7.4.3.tgz",
+      "integrity": "sha512-lIoRX3EV0wKPX8ojIrJUtsOv4+Gv8r9pfJpam/NdyYd+rs0AjDK13ieINRfBMnJkfjsWa3vmZtGMBEVvDKwTMw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "7.4.3",
+        "@storybook/core-events": "7.4.3",
+        "@storybook/global": "^5.0.0",
+        "qs": "^6.10.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/client-logger": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-7.4.3.tgz",
+      "integrity": "sha512-Nhngo9X4HjN00aRhgIVGWbwkWPe0Fz8PySuxnd8nAxSsz7KpdLFyYo2TbZZ3TX51FG5Fxcb0G5OHuunItP7EWQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/core-common": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-7.4.3.tgz",
+      "integrity": "sha512-jwIBUnWitZzw0VfKC77yN8DvTyePLVnAjbA2lPMbMIdO9ZY2lfD4AQ4QpuWsxJyAllFC4slOFDNgCDHx2AlYWw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "7.4.3",
+        "@storybook/node-logger": "7.4.3",
+        "@storybook/types": "7.4.3",
+        "@types/find-cache-dir": "^3.2.1",
+        "@types/node": "^16.0.0",
+        "@types/node-fetch": "^2.6.4",
+        "@types/pretty-hrtime": "^1.0.0",
+        "chalk": "^4.1.0",
+        "esbuild": "^0.18.0",
+        "esbuild-register": "^3.4.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/core-events": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-7.4.3.tgz",
+      "integrity": "sha512-FRfipCijMnVbGxL1ZjOLM836lyd/TGQcUFeVjTQWW/+pIGHELqDHiYeq68hqoGTKl0G0np59CJPWYTUZA4Dl9Q==",
+      "dev": true,
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/csf-tools": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-7.4.3.tgz",
+      "integrity": "sha512-nkVakGx2kzou91lGcxnyFNiSEdnpx1a53lQTl/DLm0QpDbqQuu3ZbZWXZCpXV97t/6YPeCCnGLXodnI7PZyZBA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.22.9",
+        "@babel/parser": "^7.22.7",
+        "@babel/traverse": "^7.22.8",
+        "@babel/types": "^7.22.5",
+        "@storybook/csf": "^0.1.0",
+        "@storybook/types": "7.4.3",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.1",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/node-logger": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-7.4.3.tgz",
+      "integrity": "sha512-pL13PPMUttflTWKVeDIKxPIJtBRl50Fzck12/7uiNROtBIrSV9DZSgOjInAazjo4tl+7fDj9lgkGeMEz00E8aQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/types": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-7.4.3.tgz",
+      "integrity": "sha512-DrHC1hIiw9TqDILLokDnvbUPNxGz5iJaYFEv30uvYE0s9MvgEUPblCChEUjaHOps7zQTznMPf8ULfoXlgqxk2A==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "7.4.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@types/node": {
+      "version": "16.18.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.53.tgz",
+      "integrity": "sha512-vVmHeo4tpF8zsknALU90Hh24VueYdu45ZlXzYWFbom61YR4avJqTFDC3QlWzjuTdAv6/3xHaxiO9NrtVZXrkmw==",
+      "dev": true
+    },
+    "node_modules/@storybook/telemetry/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/glob": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.5.tgz",
+      "integrity": "sha512-bYUpUD7XDEHI4Q2O5a7PXGvyw4deKR70kHiDxzQbe925wbZknhOzUt2xBgTkYL6RBcVeXYuD9iNYeqoWbBZQnA==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.0.3",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@storybook/testing-library": {
@@ -9075,9 +10028,9 @@
       "dev": true
     },
     "node_modules/@types/cross-spawn": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.2.tgz",
-      "integrity": "sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.3.tgz",
+      "integrity": "sha512-BDAkU7WHHRHnvBf5z89lcvACsvkz/n7Tv+HyD/uW76O29HoH1Tk/W6iQrepaZVbisvlEek4ygwT8IW7ow9XLAA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -14468,9 +15421,9 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "node_modules/flow-parser": {
-      "version": "0.215.1",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.215.1.tgz",
-      "integrity": "sha512-qq3rdRToqwesrddyXf+Ml8Tuf7TdoJS+EMbJgC6fHAVoBCXjb4mHelNd3J+jD8ts0bSHX81FG3LN7Qn/dcl6pA==",
+      "version": "0.216.1",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.216.1.tgz",
+      "integrity": "sha512-wstw46/C/8bRv/8RySCl15lK376j8DHxm41xFjD9eVL+jSS1UmVpbdLdA0LzGuS2v5uGgQiBLEj6mgSJQwW+MA==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -15289,14 +16242,10 @@
       }
     },
     "node_modules/headers-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.1.tgz",
-      "integrity": "sha512-jpY9fNMWPWwkqRN9CpSRNqL9svpiuSmg4CsbPl4s43KltIDIVHlPv75UOXVgc/PTP6BzHSUvd9UMdxSW1I+ETQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.3",
-        "set-cookie-parser": "^2.6.0"
-      }
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
+      "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==",
+      "dev": true
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
@@ -18523,14 +19472,14 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/msw": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-1.2.5.tgz",
-      "integrity": "sha512-Y3MwnAHX3d162eSWrEUeRdCv3+8hmgz/+Wh7OUkE6VB55+YTswxrep3yU3evZnKWHJGAM63G1s+olAgzIFdYtQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.1.tgz",
+      "integrity": "sha512-GhP5lHSTXNlZb9EaKgPRJ01YAnVXwzkvnTzRn4W8fxU2DXuJrRO+Nb6OHdYqB4fCkwSNpIJH9JkON5Y6rHqJMQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.5",
+        "@mswjs/interceptors": "^0.17.10",
         "@open-draft/until": "^1.0.3",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
@@ -18538,7 +19487,7 @@
         "chokidar": "^3.4.2",
         "cookie": "^0.4.2",
         "graphql": "^15.0.0 || ^16.0.0",
-        "headers-polyfill": "^3.1.2",
+        "headers-polyfill": "3.2.5",
         "inquirer": "^8.2.0",
         "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
@@ -18560,7 +19509,7 @@
         "url": "https://opencollective.com/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.4.x <= 5.1.x"
+        "typescript": ">= 4.4.x <= 5.2.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -21629,12 +22578,12 @@
       "dev": true
     },
     "node_modules/storybook": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-7.3.2.tgz",
-      "integrity": "sha512-Vf1C5pfF5NHQsb+33NeBd3gLGhcwbT+v6WqqIdARV7LSByqKiWNgJl2ATgzm1b4ERJo8sHU+EiJZIovFWEElkg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-7.4.3.tgz",
+      "integrity": "sha512-afp7trR23jKt8ruGMPjkNAk3A/4CaLo20iPWAODznlF7u+XWnqGm1S+ZUiJFf13Jzj8jmJf/d7/xDHxY3qVMUA==",
       "dev": true,
       "dependencies": {
-        "@storybook/cli": "7.3.2"
+        "@storybook/cli": "7.4.3"
       },
       "bin": {
         "sb": "index.js",
@@ -21985,9 +22934,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-      "integrity": "sha512-/zKt9UyngnxIT/EAGYuxaMYgOIJiP81ab9ZfkILq4oNLPFX50qyYmu7jRj9qeXoxmJHjGlbH0+cm2uy1WCs10A==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.0.tgz",
+      "integrity": "sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==",
       "dev": true,
       "dependencies": {
         "chownr": "^2.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -52,9 +52,9 @@
     "eslint-plugin-storybook": "^0.6.13",
     "jest": "^29.6.4",
     "jest-environment-jsdom": "^29.6.4",
-    "msw": "^1.2.5",
+    "msw": "^1.3.1",
     "msw-storybook-addon": "^1.8.0",
-    "storybook": "^7.3.2"
+    "storybook": "^7.4.3"
   },
   "msw": {
     "workerDirectory": "public"

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -37,15 +37,15 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
 
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
+    // {
+    //   name: "firefox",
+    //   use: { ...devices["Desktop Firefox"] },
+    // },
 
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
+    // {
+    //   name: "webkit",
+    //   use: { ...devices["Desktop Safari"] },
+    // },
 
     /* Test against mobile viewports. */
     // {

--- a/front/public/mockServiceWorker.js
+++ b/front/public/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (1.2.5).
+ * Mock Service Worker (1.3.1).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.


### PR DESCRIPTION
## 背景
npm install 時にmswとstorybook/react のバージョンミスマッチでインストールエラーになるのを解消したい
※いままでは--force で無理やりインストールしていた

```
🐷 front % npm i                                                                                                                                                                       (git)-[infra/docker]
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: msw@1.2.5
npm ERR! Found: typescript@5.2.2
npm ERR! node_modules/typescript
npm ERR!   typescript@"5.2.2" from the root project
npm ERR!   peerOptional typescript@"*" from @storybook/react@7.3.2
npm ERR!   node_modules/@storybook/react
npm ERR!     dev @storybook/react@"^7.3.2" from the root project
npm ERR!     @storybook/react@"7.3.2" from @storybook/nextjs@7.3.2
npm ERR!     node_modules/@storybook/nextjs
npm ERR!       dev @storybook/nextjs@"^7.3.2" from the root project
npm ERR!     1 more (@storybook/preset-react-webpack)
npm ERR!   6 more (@storybook/react-docgen-typescript-plugin, ...)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peerOptional typescript@">= 4.4.x <= 5.1.x" from msw@1.2.5
npm ERR! node_modules/msw
npm ERR!   dev msw@"^1.2.5" from the root project
npm ERR!   peer msw@">=0.35.0 <2.0.0" from msw-storybook-addon@1.8.0
npm ERR!   node_modules/msw-storybook-addon
npm ERR!     dev msw-storybook-addon@"^1.8.0" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: typescript@5.1.6
npm ERR! node_modules/typescript
npm ERR!   peerOptional typescript@">= 4.4.x <= 5.1.x" from msw@1.2.5
npm ERR!   node_modules/msw
npm ERR!     dev msw@"^1.2.5" from the root project
npm ERR!     peer msw@">=0.35.0 <2.0.0" from msw-storybook-addon@1.8.0
npm ERR!     node_modules/msw-storybook-addon
npm ERR!       dev msw-storybook-addon@"^1.8.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! 
npm ERR! For a full report see:
npm ERR! /Users/asakura/.npm/_logs/2023-09-21T15_15_12_842Z-eresolve-report.txt

npm ERR! A complete log of this run can be found in: /Users/asakura/.npm/_logs/2023-09-21T15_15_12_842Z-debug-0.log

```

## 変更点
* [x] mswを 1.2.5 → 1.3.1、storybookを7.3.2 → 7.4.3 にアップグレードした
* [x] 落ちていたe2eテストを調整した